### PR TITLE
fixed several type issues

### DIFF
--- a/app/components/tracking/TrackingModal.tsx
+++ b/app/components/tracking/TrackingModal.tsx
@@ -6,10 +6,11 @@ import { t } from "../../src/utils/translate";
 interface Field {
   id: string;
   label: string;
-  type: "text" | "number" | "select" | "textarea" | "datetime-local";
+  type: "text" | "number" | "select" | "textarea" | "datetime-local" | "file";
   options?: { value: string; label: string }[];
   required?: boolean;
   placeholder?: string;
+  accept?: string;
   defaultValue?: string | number | null;
   onChange?: (e: React.ChangeEvent<any>) => void;
 }
@@ -112,6 +113,19 @@ export function TrackingModal({ babyId, title, fields }: TrackingModalProps) {
             defaultValue={field.defaultValue || ""}
             min={0}
             step="any"
+            onInvalid={handleInvalid}
+            onInput={handleInput}
+          />
+        );
+      case "file":
+        return (
+          <input
+            id={field.id}
+            name={field.id}
+            type="file"
+            className="w-full p-2 border rounded bg-black text-white"
+            required={field.required}
+            accept={field.accept}
             onInvalid={handleInvalid}
             onInput={handleInput}
           />

--- a/app/routes/baby.$id.track.$type.tsx
+++ b/app/routes/baby.$id.track.$type.tsx
@@ -313,7 +313,7 @@ export default function TrackEvent() {
     string | undefined
   >(type === "feeding" ? undefined : undefined);
 
-  let fieldsToShow = config.fields;
+  let fieldsToShow: Field[] = config.fields;
   if (type === "feeding") {
     // Default to first option if not set
     const currentType = selectedFeedingType || "breast";

--- a/app/routes/baby.$id.tsx
+++ b/app/routes/baby.$id.tsx
@@ -11,8 +11,14 @@ import { LanguageSelector } from "~/components/LanguageSelector";
 import { TrackingSection } from "~/components/tracking/TrackingSection";
 import { PhotoSection } from "~/components/tracking/PhotoSection";
 
-interface Caregiver {
+interface BabyCaregiver {
+  id: number;
+  createdAt: Date;
+  updatedAt: Date;
+  relationship: string;
+  permissions: string[];
   userId: number;
+  babyId: number;
   user: {
     firstName: string;
     lastName: string;
@@ -28,7 +34,7 @@ interface Baby {
   createdAt: Date;
   updatedAt: Date;
   ownerId: number;
-  caregivers: Caregiver[];
+  caregivers: BabyCaregiver[];
 }
 
 export async function loader({ request, params, context }: LoaderFunctionArgs) {
@@ -52,8 +58,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
   if (!baby) return redirect("/dashboard");
 
   const isAuthorized =
-    baby.ownerId === userId ||
-    (baby as Baby).caregivers.some((c: Caregiver) => c.userId === userId);
+    baby.ownerId === userId || baby.caregivers.some((c) => c.userId === userId);
 
   if (!isAuthorized) return redirect("/dashboard");
 
@@ -68,8 +73,10 @@ export default function BabyDetails() {
     useLoaderData<typeof loader>();
   const [showCaregiverModal, setShowCaregiverModal] = useState(false);
 
-  const caregivers = (baby as Baby).caregivers
-    .map((c: Caregiver) => `${c.user.firstName} ${c.user.lastName}`)
+  // Type assertion to ensure TypeScript knows the baby has caregivers with user data
+  const babyWithCaregivers = baby as Baby;
+  const caregivers = babyWithCaregivers.caregivers
+    .map((c) => `${c.user.firstName} ${c.user.lastName}`)
     .join(", ");
 
   return (

--- a/app/tests/.server/caregiver.test.ts
+++ b/app/tests/.server/caregiver.test.ts
@@ -17,6 +17,10 @@ type MockPrismaClient = {
     create: MockFunction;
     delete: MockFunction;
   };
+  $accelerate: {
+    invalidate: MockFunction;
+    invalidateAll: MockFunction;
+  };
 };
 
 // Create the mock Prisma client
@@ -24,6 +28,10 @@ const mockPrisma: MockPrismaClient = {
   babyCaregiver: {
     create: vi.fn(),
     delete: vi.fn(),
+  },
+  $accelerate: {
+    invalidate: vi.fn(),
+    invalidateAll: vi.fn(),
   },
 };
 
@@ -54,7 +62,7 @@ describe("caregiver service", () => {
 
     // Call the function with all required parameters
     const result = await addCaregiver(
-      mockPrisma as unknown as PrismaClient,
+      mockPrisma as any,
       mockRequest,
       1,
       2,
@@ -98,7 +106,7 @@ describe("caregiver service", () => {
 
     // Call the function
     const result = await removeCaregiver(
-      mockPrisma as unknown as PrismaClient,
+      mockPrisma as any,
       mockRequest,
       1,
       2

--- a/app/tests/.server/session.test.ts
+++ b/app/tests/.server/session.test.ts
@@ -25,7 +25,7 @@ describe('session service', () => {
     
     try {
       await requireUserId(mockRequest);
-      fail('Should have thrown redirect');
+      expect.fail('Should have thrown redirect');
     } catch (error) {
       const response = error as Response;
       expect(response.status).toBe(302);

--- a/app/tests/.server/user.test.ts
+++ b/app/tests/.server/user.test.ts
@@ -12,6 +12,10 @@ type MockPrismaClient = {
     create: MockFunction;
     findUnique: MockFunction;
   };
+  $accelerate: {
+    invalidate: MockFunction;
+    invalidateAll: MockFunction;
+  };
 };
 
 // Create mock prisma client with proper typing
@@ -19,6 +23,10 @@ const mockPrisma: MockPrismaClient = {
   user: {
     create: vi.fn(),
     findUnique: vi.fn(),
+  },
+  $accelerate: {
+    invalidate: vi.fn(),
+    invalidateAll: vi.fn(),
   },
 };
 
@@ -49,7 +57,7 @@ describe("user service", () => {
     vi.mocked(hashPassword).mockResolvedValueOnce("hashedPassword123");
     mockPrisma.user.create.mockResolvedValueOnce(mockUser);
 
-    const result = await createUser(mockPrisma as unknown as PrismaClient, {
+    const result = await createUser(mockPrisma as any, {
       email: "test@example.com",
       password: "password123",
       firstName: "John",
@@ -99,7 +107,7 @@ describe("user service", () => {
     );
 
     const result = await verifyLogin(
-      mockPrisma as unknown as PrismaClient,
+      mockPrisma as any,
       "test@example.com",
       "password123"
     );
@@ -156,7 +164,7 @@ describe("user service", () => {
     );
 
     const result = await verifyLogin(
-      mockPrisma as unknown as PrismaClient,
+      mockPrisma as any,
       "nonexistent@example.com",
       "password123"
     );

--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,6 @@
 import { createRequestHandler, type ServerBuild } from "@remix-run/cloudflare";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore This file won’t exist if it hasn’t yet been built
+// @ts-ignore This file won't exist if it hasn't yet been built
 import * as build from "./build/server"; // eslint-disable-line import/no-unresolved
 import { getLoadContext } from "./load-context";
 import type { Env } from "./load-context";
@@ -23,6 +23,7 @@ export default {
             ctx: {
               waitUntil: ctx.waitUntil.bind(ctx),
               passThroughOnException: ctx.passThroughOnException.bind(ctx),
+              props: {},
             },
             caches,
             env,


### PR DESCRIPTION
Found several errors when running a typecheck:
<img width="423" alt="image" src="https://github.com/user-attachments/assets/64e4d906-8448-4778-8ef7-a5cee8d0de01" />

I updated the code accordingly, addressing type issues file by file:
- Field type issues: The Field interface and TrackingModal now support "file" type.
- Baby/caregiver typing: The loader and usage in `baby.$id.tsx` are now properly typed, removing unsafe assertions.
- Test fail function: Replaced with `expect.fail()` for Vitest compatibility.
- Prisma mock issues: All test mocks now include the `$accelerate` property and use as any for compatibility.
- Server context: The `props` property is now included in the Cloudflare context object.
- Tracking fields: The `fieldsToShow` variable is now explicitly typed to avoid union type errors