### PR TITLE
fix: move language selector to global header

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -11,6 +11,7 @@ import {
 } from "@remix-run/react";
 import type { LinksFunction, LoaderFunctionArgs } from "@remix-run/node";
 import { getCurrentLanguage, setLanguage } from "~/src/utils/translate";
+import { LanguageSelector } from "~/components/LanguageSelector";
 import { useEffect } from "react";
 
 import "./tailwind.css";
@@ -68,7 +69,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <body className="bg-gray-900 text-white">
         {!isLoginPage && (
           <header className="fixed top-0 left-0 w-full bg-blue shadow-sm z-10">
-            <div className="max-w-7xl mx-auto px-4 py-2 flex items-center">
+            <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-between">
               <Link
                 to="/dashboard"
                 className="flex items-center justify-center p-2 rounded-full hover:bg-blue transition-colors text-white"
@@ -88,6 +89,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
                   <polyline points="9 22 9 12 15 12 15 22"></polyline>
                 </svg>
               </Link>
+              <div className="flex items-center">
+                <LanguageSelector />
+              </div>
             </div>
           </header>
         )}

--- a/app/routes/baby.$id.tsx
+++ b/app/routes/baby.$id.tsx
@@ -7,7 +7,6 @@ import { getRecentTrackingEvents } from "~/.server/tracking";
 import { PlusIcon } from "lucide-react";
 import AddCaregiverModal from "~/components/AddCaregiverModal";
 import { t } from "~/src/utils/translate";
-import { LanguageSelector } from "~/components/LanguageSelector";
 import { TrackingSection } from "~/components/tracking/TrackingSection";
 import { PhotoSection } from "~/components/tracking/PhotoSection";
 
@@ -83,29 +82,21 @@ export default function BabyDetails() {
     <>
       <div>
         <div className="max-w-6xl mx-auto p-6">
-          <div className="flex flex-col md:flex-row md:justify-between md:items-center mb-6">
-            <div className="flex flex-col">
-              <h1 className="text-2xl font-bold">
-                {baby.firstName} {baby.lastName}
-              </h1>
-              <div className="flex items-center gap-2 mt-2">
-                <span className="text-lg font-normal text-gray-600">
-                  {t("baby.caregivers")}: {caregivers}
-                </span>
-                <button
-                  onClick={() => setShowCaregiverModal(true)}
-                  className="p-1 rounded-full hover:bg-gray-100"
-                  aria-label="Add caregiver"
-                >
-                  <PlusIcon className="w-5 h-5" />
-                </button>
-              </div>
-            </div>
-            <div className="flex items-center gap-2 mt-4 md:mt-0 md:self-start md:justify-end w-full md:w-auto">
-              <span className="text-sm text-gray-300">
-                {t("settings.language")}:
+          <div className="flex flex-col mb-6">
+            <h1 className="text-2xl font-bold">
+              {baby.firstName} {baby.lastName}
+            </h1>
+            <div className="flex items-center gap-2 mt-2">
+              <span className="text-lg font-normal text-gray-600">
+                {t("baby.caregivers")}: {caregivers}
               </span>
-              <LanguageSelector />
+              <button
+                onClick={() => setShowCaregiverModal(true)}
+                className="p-1 rounded-full hover:bg-gray-100"
+                aria-label="Add caregiver"
+              >
+                <PlusIcon className="w-5 h-5" />
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Simplified and moved the language selector to the global header (top-right corner) at `root.tsx`; now it lives there unfading, ever-present. A reminder of language's persistence  across our finite existence 
 
<img width="1000" height="328" alt="image" src="https://github.com/user-attachments/assets/712812a0-ee54-47f1-afab-0192c5743cb3" />

<img width="1001" height="347" alt="image" src="https://github.com/user-attachments/assets/39548e7b-54c2-4ea9-9767-2fd68ca57c1c" />